### PR TITLE
Show tooltip on click for touch and allow to disable when touch device

### DIFF
--- a/dist/popbox.bower.js
+++ b/dist/popbox.bower.js
@@ -2,7 +2,7 @@
  * popbox - Tooltip/Popover Library
  * v0.11.4
  * https://github.com/firstandthird/popbox
- * copyright First + Third 2014
+ * copyright First + Third 2016
  * MIT License
 */
 (function($) {
@@ -15,7 +15,8 @@
       animOffset: 5,
       hideTimeout: 100,
       enableHover: true,
-      clickToShow: true
+      clickToShow: true,
+      isTouch: ('ontouchstart' in window)
     },
 
     init: function () {
@@ -27,6 +28,7 @@
       this.title = this.el.data('popbox-title') || '';
       this.templateEl = this.el.data('popbox-el') || '';
       this.direction = this.el.data('popbox-direction') || this.direction;
+      this.disableOnTouch = this.el.data('disable-touch');
       this.template = '';
 
       this.transitionEvents = 'webkitTransitionEnd otransitionend oTransitionEnd msTransitionEnd transitionend';
@@ -39,9 +41,11 @@
     },
 
     attachEvents: function () {
-      if(this.enableHover) {
+      if(this.enableHover && !this.isTouch) {
         this.el.bind('mouseenter.popbox', this.proxy(this.show));
         this.el.bind('mouseleave.popbox', this.proxy(this.hide));
+      } else if(this.isTouch && !this.disableOnTouch) {
+        this.el.bind('click.popbox', this.proxy(this.toggle));
       }
     },
 
@@ -54,7 +58,7 @@
 
     show: function (e) {
       if(this.hoveringOverTooltip) return;
-      
+
       if (!this.text) {
         return;
       }
@@ -106,7 +110,7 @@
         }));
 
         this.open = false;
-        
+
       }), this.hideTimeout);
     },
 

--- a/dist/popbox.css
+++ b/dist/popbox.css
@@ -3,13 +3,11 @@
   color: #ffffff;
   border-radius: 4px;
   padding: 10px;
-  -webkit-transition: opacity, -webkit-transform;
+  transition: opacity, -webkit-transform;
   transition: opacity, transform;
-  -webkit-transition-duration: 200ms;
   transition-duration: 200ms;
   opacity: 0;
   -webkit-transform: translate(0, 0);
-  -ms-transform: translate(0, 0);
   transform: translate(0, 0);
 }
 .popbox.left {
@@ -31,7 +29,6 @@
 }
 .popbox.left.open {
   -webkit-transform: translate(5px, 0);
-  -ms-transform: translate(5px, 0);
   transform: translate(5px, 0);
 }
 .popbox.up,
@@ -67,7 +64,6 @@
 .popbox.left-up.open,
 .popbox.right-up.open {
   -webkit-transform: translate(0, 5px);
-  -ms-transform: translate(0, 5px);
   transform: translate(0, 5px);
 }
 .popbox.right {
@@ -96,7 +92,6 @@
 }
 .popbox.right.open {
   -webkit-transform: translate(-5px, 0);
-  -ms-transform: translate(-5px, 0);
   transform: translate(-5px, 0);
 }
 .popbox.down {
@@ -125,7 +120,6 @@
 }
 .popbox.down.open {
   -webkit-transform: translate(0, -5px);
-  -ms-transform: translate(0, -5px);
   transform: translate(0, -5px);
 }
 .popbox .title {

--- a/dist/popbox.js
+++ b/dist/popbox.js
@@ -2,199 +2,9 @@
  * popbox - Tooltip/Popover Library
  * v0.11.4
  * https://github.com/firstandthird/popbox
- * copyright First + Third 2014
+ * copyright First + Third 2016
  * MIT License
 */
-/*!
- * fidel - a ui view controller
- * v2.2.5
- * https://github.com/jgallen23/fidel
- * copyright Greg Allen 2014
- * MIT License
-*/
-(function(w, $) {
-  var _id = 0;
-  var Fidel = function(obj) {
-    this.obj = obj;
-  };
-
-  Fidel.prototype.__init = function(options) {
-    $.extend(this, this.obj);
-    this.id = _id++;
-    this.namespace = '.fidel' + this.id;
-    this.obj.defaults = this.obj.defaults || {};
-    $.extend(this, this.obj.defaults, options);
-    $('body').trigger('FidelPreInit', this);
-    this.setElement(this.el || $('<div/>'));
-    if (this.init) {
-      this.init();
-    }
-    $('body').trigger('FidelPostInit', this);
-  };
-  Fidel.prototype.eventSplitter = /^(\w+)\s*(.*)$/;
-
-  Fidel.prototype.setElement = function(el) {
-    this.el = el;
-    this.getElements();
-    this.dataElements();
-    this.delegateEvents();
-    this.delegateActions();
-  };
-
-  Fidel.prototype.find = function(selector) {
-    return this.el.find(selector);
-  };
-
-  Fidel.prototype.proxy = function(func) {
-    return $.proxy(func, this);
-  };
-
-  Fidel.prototype.getElements = function() {
-    if (!this.elements)
-      return;
-
-    for (var selector in this.elements) {
-      var elemName = this.elements[selector];
-      this[elemName] = this.find(selector);
-    }
-  };
-
-  Fidel.prototype.dataElements = function() {
-    var self = this;
-    this.find('[data-element]').each(function(index, item) {
-      var el = $(item);
-      var name = el.data('element');
-      self[name] = el;
-    });
-  };
-
-  Fidel.prototype.delegateEvents = function() {
-    if (!this.events)
-      return;
-    for (var key in this.events) {
-      var methodName = this.events[key];
-      var match = key.match(this.eventSplitter);
-      var eventName = match[1], selector = match[2];
-
-      var method = this.proxy(this[methodName]);
-
-      if (selector === '') {
-        this.el.on(eventName + this.namespace, method);
-      } else {
-        if (this[selector] && typeof this[selector] != 'function') {
-          this[selector].on(eventName + this.namespace, method);
-        } else {
-          this.el.on(eventName + this.namespace, selector, method);
-        }
-      }
-    }
-  };
-
-  Fidel.prototype.delegateActions = function() {
-    var self = this;
-    self.el.on('click'+this.namespace, '[data-action]', function(e) {
-      var el = $(this);
-      var action = el.attr('data-action');
-      if (self[action]) {
-        self[action](e, el);
-      }
-    });
-  };
-
-  Fidel.prototype.on = function(eventName, cb) {
-    this.el.on(eventName+this.namespace, cb);
-  };
-
-  Fidel.prototype.one = function(eventName, cb) {
-    this.el.one(eventName+this.namespace, cb);
-  };
-
-  Fidel.prototype.emit = function(eventName, data, namespaced) {
-    var ns = (namespaced) ? this.namespace : '';
-    this.el.trigger(eventName+ns, data);
-  };
-
-  Fidel.prototype.hide = function() {
-    if (this.views) {
-      for (var key in this.views) {
-        this.views[key].hide();
-      }
-    }
-    this.el.hide();
-  };
-  Fidel.prototype.show = function() {
-    if (this.views) {
-      for (var key in this.views) {
-        this.views[key].show();
-      }
-    }
-    this.el.show();
-  };
-
-  Fidel.prototype.destroy = function() {
-    this.el.empty();
-    this.emit('destroy');
-    this.el.unbind(this.namespace);
-  };
-
-  Fidel.declare = function(obj) {
-    var FidelModule = function(el, options) {
-      this.__init(el, options);
-    };
-    FidelModule.prototype = new Fidel(obj);
-    return FidelModule;
-  };
-
-  //for plugins
-  Fidel.onPreInit = function(fn) {
-    $('body').on('FidelPreInit', function(e, obj) {
-      fn.call(obj);
-    });
-  };
-  Fidel.onPostInit = function(fn) {
-    $('body').on('FidelPostInit', function(e, obj) {
-      fn.call(obj);
-    });
-  };
-  w.Fidel = Fidel;
-})(window, window.jQuery || window.Zepto);
-
-(function($) {
-  $.declare = function(name, obj) {
-
-    $.fn[name] = function() {
-      var args = Array.prototype.slice.call(arguments);
-      var options = args.shift();
-      var methodValue;
-      var els;
-
-      els = this.each(function() {
-        var $this = $(this);
-
-        var data = $this.data(name);
-
-        if (!data) {
-          var View = Fidel.declare(obj);
-          var opts = $.extend({}, options, { el: $this });
-          data = new View(opts);
-          $this.data(name, data); 
-        }
-        if (typeof options === 'string') {
-          methodValue = data[options].apply(data, args);
-        }
-      });
-
-      return (typeof methodValue !== 'undefined') ? methodValue : els;
-    };
-
-    $.fn[name].defaults = obj.defaults || {};
-
-  };
-
-  $.Fidel = window.Fidel;
-
-})(jQuery);
-
 (function($) {
   $.declare('popbox', {
     defaults: {
@@ -205,7 +15,8 @@
       animOffset: 5,
       hideTimeout: 100,
       enableHover: true,
-      clickToShow: true
+      clickToShow: true,
+      isTouch: ('ontouchstart' in window)
     },
 
     init: function () {
@@ -217,6 +28,7 @@
       this.title = this.el.data('popbox-title') || '';
       this.templateEl = this.el.data('popbox-el') || '';
       this.direction = this.el.data('popbox-direction') || this.direction;
+      this.disableOnTouch = this.el.data('disable-touch');
       this.template = '';
 
       this.transitionEvents = 'webkitTransitionEnd otransitionend oTransitionEnd msTransitionEnd transitionend';
@@ -229,9 +41,11 @@
     },
 
     attachEvents: function () {
-      if(this.enableHover) {
+      if(this.enableHover && !this.isTouch) {
         this.el.bind('mouseenter.popbox', this.proxy(this.show));
         this.el.bind('mouseleave.popbox', this.proxy(this.hide));
+      } else if(this.isTouch && !this.disableOnTouch) {
+        this.el.bind('click.popbox', this.proxy(this.toggle));
       }
     },
 
@@ -244,7 +58,7 @@
 
     show: function (e) {
       if(this.hoveringOverTooltip) return;
-      
+
       if (!this.text) {
         return;
       }
@@ -296,7 +110,7 @@
         }));
 
         this.open = false;
-        
+
       }), this.hideTimeout);
     },
 

--- a/example/index.html
+++ b/example/index.html
@@ -31,6 +31,7 @@
       <a href="#" class="hover-popbox-topright" data-popbox data-popbox-text="This is a tooltip" data-action="toggle" data-popbox-direction="right-up">Tooltip 1</a>
       <a href="#" class="hover-popbox-topright" data-popbox data-popbox-text="This is a tooltip" data-action="toggle" data-popbox-direction="smart">Tooltip Smart</a>
       <a href="#" class="hover-popbox" data-popbox data-popbox-text="" data-action="toggle">Blank Tooltip</a>
+      <a href="#" class="hover-popbox-topright" data-popbox data-popbox-text="This tooltip is disabled on touch devices" data-action="toggle" data-popbox-direction="smart" data-disable-touch="true">Disable Touch Tooltip</a>
       <div class="custom-popbox-content" style="display: none;">
         <div class="content">
           <strong>This is a custom title</strong><br>

--- a/lib/popbox.js
+++ b/lib/popbox.js
@@ -8,7 +8,8 @@
       animOffset: 5,
       hideTimeout: 100,
       enableHover: true,
-      clickToShow: true
+      clickToShow: true,
+      isTouch: ('ontouchstart' in window)
     },
 
     init: function () {
@@ -20,6 +21,7 @@
       this.title = this.el.data('popbox-title') || '';
       this.templateEl = this.el.data('popbox-el') || '';
       this.direction = this.el.data('popbox-direction') || this.direction;
+      this.disableOnTouch = this.el.data('disable-touch');
       this.template = '';
 
       this.transitionEvents = 'webkitTransitionEnd otransitionend oTransitionEnd msTransitionEnd transitionend';
@@ -32,9 +34,11 @@
     },
 
     attachEvents: function () {
-      if(this.enableHover) {
+      if(this.enableHover && !this.isTouch) {
         this.el.bind('mouseenter.popbox', this.proxy(this.show));
         this.el.bind('mouseleave.popbox', this.proxy(this.hide));
+      } else if(this.isTouch && !this.disableOnTouch) {
+        this.el.bind('click.popbox', this.proxy(this.toggle));
       }
     },
 
@@ -47,7 +51,7 @@
 
     show: function (e) {
       if(this.hoveringOverTooltip) return;
-      
+
       if (!this.text) {
         return;
       }
@@ -99,7 +103,7 @@
         }));
 
         this.open = false;
-        
+
       }), this.hideTimeout);
     },
 


### PR DESCRIPTION
When a touch device is detected the hover event is changed to a click event. If there is a need to disable the tool tip on a touch device, because there is already a click event on the icon, just add `data-disable-touch`.
